### PR TITLE
[Fix] 인증 시스템 에러 처리 및 상태 관리 보완

### DIFF
--- a/src/lib/store/authStore.ts
+++ b/src/lib/store/authStore.ts
@@ -122,13 +122,26 @@ const useAuthStore = create<AuthStore>()((set, get) => ({
       // 토큰이 있으면 Bearer 인증, 없으면 쿠키 인증 시도
       const user = await AuthAPI.getCurrentUser(token || undefined)
 
-      set({
-        user,
-        isAuthenticated: true,
-        isLoading: false,
-        hasAuthChecked: true,
-      })
+      if (user) {
+        set({
+          user,
+          isAuthenticated: true,
+          isLoading: false,
+          hasAuthChecked: true,
+          error: null,
+        })
+      } else {
+        set({
+          user: null,
+          token: null,
+          isAuthenticated: false,
+          isLoading: false,
+          error: null,
+          hasAuthChecked: true,
+        })
+      }
     } catch (error) {
+      console.error('❌ Failed to restore auth state:', error)
       set({
         user: null,
         token: null,


### PR DESCRIPTION
## Summary
- 인증 API의 에러 처리 로직을 개선하여 비로그인 상태를 정상적으로 처리
- getCurrentUser 함수의 반환 타입을 User | null로 변경
- 401/403 응답에 대한 적절한 처리 로직 추가

## Changes
- `getCurrentUser` API 함수에서 401/403 상태 코드를 에러가 아닌 null 반환으로 처리
- 인증 스토어의 상태 복원 로직에서 null 사용자 정보에 대한 적절한 상태 업데이트
- JSON 파싱 실패에 대한 방어 코드 추가

## Test Plan
- [ ] 로그인 상태에서 사용자 정보 조회 정상 작동
- [ ] 비로그인 상태에서 에러 없이 null 반환
- [ ] 인증 토큰 만료 시 적절한 상태 전환
- [ ] 네트워크 에러 시 에러 처리 정상 작동