### PR TITLE
Feat: 쉬운 편집 모드에 자동 줄바꿈 기능 추가

### DIFF
--- a/src/app/(route)/editor/components/SimpleToolbar.tsx
+++ b/src/app/(route)/editor/components/SimpleToolbar.tsx
@@ -28,6 +28,7 @@ interface SimpleToolbarProps {
   onRedo: () => void
   onSplitClip: () => void
   onToggleTemplateSidebar: () => void
+  onAutoLineBreak?: () => void
   onSave?: () => void
   onSaveAs?: () => void
   forceOpenExportModal?: boolean
@@ -44,6 +45,7 @@ const SimpleToolbar: React.FC<SimpleToolbarProps> = ({
   onRedo,
   onSplitClip,
   onToggleTemplateSidebar,
+  onAutoLineBreak,
   onSave,
   onSaveAs,
   forceOpenExportModal,
@@ -226,6 +228,30 @@ const SimpleToolbar: React.FC<SimpleToolbarProps> = ({
             disabled={!activeClipId}
             shortcut="Enter"
           />
+
+          {/* 자동 줄바꿈 */}
+          {onAutoLineBreak && (
+            <ToolbarButton
+              icon={
+                <svg fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M4 6h16M4 12h8m-8 6h16"
+                  />
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M14 12l4 4m0-4l-4 4"
+                  />
+                </svg>
+              }
+              label="자동 줄바꿈"
+              onClick={onAutoLineBreak}
+            />
+          )}
 
           {/* 템플릿 */}
           <ToolbarButton

--- a/src/app/(route)/editor/page.tsx
+++ b/src/app/(route)/editor/page.tsx
@@ -1875,6 +1875,7 @@ export default function EditorPage() {
                 onRedo={handleRedo}
                 onSplitClip={handleSplitClip}
                 onToggleTemplateSidebar={handleToggleTemplateSidebar}
+                onAutoLineBreak={handleAutoLineBreak}
                 onSave={handleSave}
                 onSaveAs={handleSaveAs}
                 forceOpenExportModal={shouldOpenExportModal}


### PR DESCRIPTION
## Summary
- 쉬운 편집 모드에서도 상세 편집과 동일한 자동 줄바꿈 기능 사용 가능
- SimpleToolbar 컴포넌트에 줄바꿈 버튼 추가
- editor page에서 handleAutoLineBreak 핸들러 연결

## Changes
- `SimpleToolbar.tsx`: onAutoLineBreak prop 및 자동 줄바꿈 버튼 추가
- `page.tsx`: SimpleToolbar에 onAutoLineBreak prop 전달

## Test plan
- [x] 쉬운 편집 모드에서 줄바꿈 버튼 표시 확인
- [x] 버튼 클릭 시 자동 줄바꿈 기능 동작 확인
- [x] 상세 편집 모드에서 기존 기능 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.ai/code)