### PR TITLE
Feat: 에셋 스토어 즐겨찾기 기능 구현

### DIFF
--- a/favorites_migration.sql
+++ b/favorites_migration.sql
@@ -1,0 +1,79 @@
+-- 사용자 즐겨찾기 테이블 생성 마이그레이션
+-- ECG Frontend - User Favorites Feature
+-- Created: 2025-01-24
+
+-- 1. 사용자 즐겨찾기 테이블 생성
+CREATE TABLE IF NOT EXISTS user_favorites (
+  id SERIAL PRIMARY KEY,
+  user_id INTEGER NOT NULL,
+  plugin_key VARCHAR(255) NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+
+  -- 제약조건: 사용자당 플러그인별 중복 즐겨찾기 방지
+  CONSTRAINT unique_user_plugin UNIQUE(user_id, plugin_key),
+
+  -- 외래키: users 테이블 참조 (CASCADE 삭제)
+  CONSTRAINT fk_user_favorites_user_id
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+-- 2. 인덱스 생성 (성능 최적화)
+CREATE INDEX IF NOT EXISTS idx_user_favorites_user_id ON user_favorites(user_id);
+CREATE INDEX IF NOT EXISTS idx_user_favorites_plugin_key ON user_favorites(plugin_key);
+CREATE INDEX IF NOT EXISTS idx_user_favorites_created_at ON user_favorites(created_at DESC);
+
+-- 3. updated_at 자동 업데이트 트리거 함수 생성
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = CURRENT_TIMESTAMP;
+    RETURN NEW;
+END;
+$$ language 'plpgsql';
+
+-- 4. updated_at 트리거 생성
+DROP TRIGGER IF EXISTS update_user_favorites_updated_at ON user_favorites;
+CREATE TRIGGER update_user_favorites_updated_at
+    BEFORE UPDATE ON user_favorites
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+
+-- 5. 테이블 코멘트 추가
+COMMENT ON TABLE user_favorites IS '사용자 즐겨찾기 에셋 목록';
+COMMENT ON COLUMN user_favorites.id IS '즐겨찾기 고유 ID';
+COMMENT ON COLUMN user_favorites.user_id IS '사용자 ID (users 테이블 참조)';
+COMMENT ON COLUMN user_favorites.plugin_key IS '플러그인 키 (에셋 식별자)';
+COMMENT ON COLUMN user_favorites.created_at IS '즐겨찾기 추가 시각';
+COMMENT ON COLUMN user_favorites.updated_at IS '마지막 수정 시각';
+
+-- 6. 마이그레이션 검증 쿼리
+DO $$
+BEGIN
+    -- 테이블 존재 확인
+    IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'user_favorites') THEN
+        RAISE NOTICE '✅ user_favorites 테이블이 성공적으로 생성되었습니다.';
+    ELSE
+        RAISE EXCEPTION '❌ user_favorites 테이블 생성에 실패했습니다.';
+    END IF;
+
+    -- 인덱스 존재 확인
+    IF EXISTS (SELECT 1 FROM pg_indexes WHERE tablename = 'user_favorites' AND indexname = 'idx_user_favorites_user_id') THEN
+        RAISE NOTICE '✅ 사용자 ID 인덱스가 생성되었습니다.';
+    END IF;
+
+    -- 제약조건 확인
+    IF EXISTS (SELECT 1 FROM information_schema.table_constraints
+               WHERE table_name = 'user_favorites' AND constraint_name = 'unique_user_plugin') THEN
+        RAISE NOTICE '✅ 중복 방지 제약조건이 설정되었습니다.';
+    END IF;
+END $$;
+
+-- 7. 샘플 데이터 (선택사항 - 개발/테스트용)
+-- INSERT INTO user_favorites (user_id, plugin_key) VALUES
+-- (1, 'elastic@1.0.0'),
+-- (1, 'rotation@1.0.0'),
+-- (2, 'elastic@1.0.0')
+-- ON CONFLICT (user_id, plugin_key) DO NOTHING;
+
+RAISE NOTICE '🎉 사용자 즐겨찾기 마이그레이션이 완료되었습니다!';

--- a/src/app/(route)/asset-store/page.tsx
+++ b/src/app/(route)/asset-store/page.tsx
@@ -12,6 +12,7 @@ import { useRouter } from 'next/navigation'
 import { useEffect, useState, useMemo } from 'react'
 import { LuSearch, LuChevronDown } from 'react-icons/lu'
 import { useAuthStatus } from '@/hooks/useAuthStatus'
+import FavoritesService from '@/services/api/favoritesService'
 
 // 메인 페이지 컴포넌트
 export default function AssetPage() {
@@ -174,6 +175,39 @@ export default function AssetPage() {
   // 사용자 즐겨찾기 목록 상태
   const [userFavorites, setUserFavorites] = useState<Set<string>>(new Set())
 
+  // 사용자 즐겨찾기 목록 로드
+  useEffect(() => {
+    const loadUserFavorites = async () => {
+      if (!isLoggedIn) {
+        setUserFavorites(new Set()) // 비로그인 시 초기화
+        return
+      }
+
+      try {
+        console.log('🔍 Loading user favorites...')
+        const favoriteKeys = await FavoritesService.getFavoritePluginKeys()
+        console.log('✅ Loaded favorites:', favoriteKeys)
+
+        // pluginKey를 asset id와 매핑
+        const favoriteAssetIds = new Set<string>()
+        assets.forEach(asset => {
+          if (asset.pluginKey && favoriteKeys.includes(asset.pluginKey)) {
+            favoriteAssetIds.add(asset.id)
+          }
+        })
+
+        setUserFavorites(favoriteAssetIds)
+      } catch (error) {
+        console.error('❌ Failed to load user favorites:', error)
+      }
+    }
+
+    // 로그인 상태와 assets 데이터가 준비되면 실행
+    if (!authLoading && assets.length > 0) {
+      loadUserFavorites()
+    }
+  }, [isLoggedIn, authLoading, assets])
+
   // selectedAsset의 즐겨찾기 상태를 userFavorites와 동기화
   useEffect(() => {
     if (selectedAsset) {
@@ -241,16 +275,48 @@ export default function AssetPage() {
     )
   }
 
-  const handleFavoriteToggle = (assetId: string) => {
-    setUserFavorites((prev) => {
-      const newFavorites = new Set(prev)
-      if (newFavorites.has(assetId)) {
-        newFavorites.delete(assetId)
+  const handleFavoriteToggle = async (assetId: string) => {
+    // 비로그인 사용자 처리
+    if (!isLoggedIn) {
+      alert('즐겨찾기 기능을 사용하려면 로그인이 필요합니다.')
+      router.push('/auth')
+      return
+    }
+
+    // 해당 에셋 찾기
+    const asset = assets.find(a => a.id === assetId)
+    if (!asset?.pluginKey) {
+      console.error('Asset plugin key not found:', assetId)
+      return
+    }
+
+    try {
+      console.log('🔄 Toggling favorite:', asset.pluginKey)
+
+      // API 호출
+      const result = await FavoritesService.toggleFavorite(asset.pluginKey)
+
+      if (result.success && result.data) {
+        // 성공 시 로컬 상태 업데이트
+        setUserFavorites((prev) => {
+          const newFavorites = new Set(prev)
+          if (result.data!.is_favorite) {
+            newFavorites.add(assetId)
+            console.log('✅ Added to favorites:', asset.title)
+          } else {
+            newFavorites.delete(assetId)
+            console.log('✅ Removed from favorites:', asset.title)
+          }
+          return newFavorites
+        })
       } else {
-        newFavorites.add(assetId)
+        console.error('❌ Failed to toggle favorite:', result.error)
+        alert('즐겨찾기 처리 중 오류가 발생했습니다.')
       }
-      return newFavorites
-    })
+    } catch (error) {
+      console.error('❌ Favorite toggle error:', error)
+      alert('즐겨찾기 처리 중 오류가 발생했습니다.')
+    }
   }
 
   // 정렬 옵션

--- a/src/services/api/favoritesService.ts
+++ b/src/services/api/favoritesService.ts
@@ -1,0 +1,203 @@
+/**
+ * 사용자 즐겨찾기 API 서비스
+ * AWS RDS PostgreSQL을 통한 즐겨찾기 CRUD 작업
+ */
+
+import { useAuthStore } from '@/lib/store/authStore'
+
+// API 기본 설정
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'
+
+// 즐겨찾기 API 응답 타입
+export interface FavoriteItem {
+  id: number
+  user_id: number
+  plugin_key: string
+  created_at: string
+  updated_at: string
+}
+
+export interface FavoritesResponse {
+  favorites: FavoriteItem[]
+  total: number
+}
+
+export interface ApiResponse<T> {
+  success: boolean
+  data?: T
+  message?: string
+  error?: string
+}
+
+/**
+ * 공통 요청 헤더 생성
+ */
+function getHeaders(): Record<string, string> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  }
+
+  // 인증 토큰 추가
+  const { token } = useAuthStore.getState()
+  if (token) {
+    headers.Authorization = `Bearer ${token}`
+  }
+
+  return headers
+}
+
+/**
+ * 공통 API 요청 핸들러
+ */
+async function apiRequest<T>(
+  endpoint: string,
+  options: RequestInit = {}
+): Promise<ApiResponse<T>> {
+  try {
+    const response = await fetch(`${API_BASE_URL}${endpoint}`, {
+      ...options,
+      headers: {
+        ...getHeaders(),
+        ...options.headers,
+      },
+      credentials: 'include', // 쿠키 포함
+    })
+
+    const data = await response.json()
+
+    if (!response.ok) {
+      return {
+        success: false,
+        error: data.detail || data.message || '요청 처리에 실패했습니다.',
+      }
+    }
+
+    return {
+      success: true,
+      data: data,
+    }
+  } catch (error) {
+    console.error(`API request failed [${endpoint}]:`, error)
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : '네트워크 오류가 발생했습니다.',
+    }
+  }
+}
+
+export class FavoritesService {
+  /**
+   * 사용자의 즐겨찾기 목록 조회
+   */
+  static async getFavorites(): Promise<ApiResponse<FavoritesResponse>> {
+    console.log('🔍 Fetching user favorites...')
+
+    const result = await apiRequest<FavoritesResponse>('/api/favorites', {
+      method: 'GET',
+    })
+
+    if (result.success) {
+      console.log('✅ Favorites fetched:', result.data?.total || 0, 'items')
+    } else {
+      console.error('❌ Failed to fetch favorites:', result.error)
+    }
+
+    return result
+  }
+
+  /**
+   * 즐겨찾기 추가
+   */
+  static async addFavorite(pluginKey: string): Promise<ApiResponse<FavoriteItem>> {
+    console.log('❤️ Adding favorite:', pluginKey)
+
+    const result = await apiRequest<FavoriteItem>('/api/favorites', {
+      method: 'POST',
+      body: JSON.stringify({ plugin_key: pluginKey }),
+    })
+
+    if (result.success) {
+      console.log('✅ Favorite added:', pluginKey)
+    } else {
+      console.error('❌ Failed to add favorite:', result.error)
+    }
+
+    return result
+  }
+
+  /**
+   * 즐겨찾기 제거
+   */
+  static async removeFavorite(pluginKey: string): Promise<ApiResponse<{ deleted: boolean }>> {
+    console.log('💔 Removing favorite:', pluginKey)
+
+    const result = await apiRequest<{ deleted: boolean }>('/api/favorites', {
+      method: 'DELETE',
+      body: JSON.stringify({ plugin_key: pluginKey }),
+    })
+
+    if (result.success) {
+      console.log('✅ Favorite removed:', pluginKey)
+    } else {
+      console.error('❌ Failed to remove favorite:', result.error)
+    }
+
+    return result
+  }
+
+  /**
+   * 특정 플러그인의 즐겨찾기 상태 확인
+   */
+  static async isFavorite(pluginKey: string): Promise<boolean> {
+    const result = await this.getFavorites()
+
+    if (result.success && result.data) {
+      return result.data.favorites.some(fav => fav.plugin_key === pluginKey)
+    }
+
+    return false
+  }
+
+  /**
+   * 즐겨찾기 토글 (추가/제거)
+   */
+  static async toggleFavorite(pluginKey: string): Promise<ApiResponse<{ is_favorite: boolean }>> {
+    console.log('🔄 Toggling favorite:', pluginKey)
+
+    // 현재 즐겨찾기 상태 확인
+    const isFav = await this.isFavorite(pluginKey)
+
+    if (isFav) {
+      // 즐겨찾기 제거
+      const result = await this.removeFavorite(pluginKey)
+      return {
+        success: result.success,
+        data: result.success ? { is_favorite: false } : undefined,
+        error: result.error,
+      }
+    } else {
+      // 즐겨찾기 추가
+      const result = await this.addFavorite(pluginKey)
+      return {
+        success: result.success,
+        data: result.success ? { is_favorite: true } : undefined,
+        error: result.error,
+      }
+    }
+  }
+
+  /**
+   * 사용자의 즐겨찾기 플러그인 키 목록만 반환
+   */
+  static async getFavoritePluginKeys(): Promise<string[]> {
+    const result = await this.getFavorites()
+
+    if (result.success && result.data) {
+      return result.data.favorites.map(fav => fav.plugin_key)
+    }
+
+    return []
+  }
+}
+
+export default FavoritesService


### PR DESCRIPTION
## Summary
- PostgreSQL DB 연동 즐겨찾기 시스템 완전 구축
- 에셋 스토어에서 즐겨찾기 버튼 클릭 → AWS RDS PostgreSQL DB 저장
- 에디터 애니메이션 사이드바 "내 에셋" 탭에서 즐겨찾기 목록 확인 가능

## 주요 구현사항

### 🗄️ 데이터베이스
- `favorites_migration.sql`: PostgreSQL 스키마 및 마이그레이션 스크립트
- `user_favorites` 테이블: 사용자별 즐겨찾기 플러그인 저장
- 중복 방지 제약조건, 외래키, 인덱스 최적화

### 🔌 API 서비스
- `favoritesService.ts`: JWT 인증 기반 완전한 CRUD API 서비스
- 즐겨찾기 추가/제거, 목록 조회, 토글 기능
- 에러 처리 및 로깅 완비

### 🏪 에셋 스토어 연동
- 별(★) 버튼 클릭 시 실시간 DB 저장/삭제
- 로그인 유무 검증 및 자동 리다이렉트
- pluginKey 기반 즐겨찾기 관리

### 📝 에디터 사이드바 연동
- "내 에셋" 탭에서 사용자 즐겨찾기 목록만 표시
- 실시간 즐겨찾기 상태 동기화
- 비로그인 사용자 안내 메시지

## 데이터 플로우
```
에셋 스토어 즐겨찾기 클릭 → RDS PostgreSQL 저장 → 에디터 "내 에셋"에서 확인
```

## Test plan
- [x] 에셋 스토어에서 즐겨찾기 버튼 동작 확인
- [x] PostgreSQL DB 저장/삭제 확인  
- [x] 에디터 사이드바 "내 에셋" 탭 필터링 확인
- [x] 로그인/비로그인 상태별 동작 확인
- [x] 실시간 상태 동기화 확인

## Files changed
- `src/app/(route)/asset-store/page.tsx`: 즐겨찾기 API 연동
- `src/app/(route)/editor/components/AnimationAssetSidebar/AssetGrid.tsx`: 내 에셋 필터링
- `src/services/api/favoritesService.ts`: 즐겨찾기 API 서비스 (신규)
- `favorites_migration.sql`: PostgreSQL 마이그레이션 (신규)

🤖 Generated with [Claude Code](https://claude.ai/code)