### PR TITLE
[Fix] 단어 클릭 시 정확한 시간 탐색 개선

### DIFF
--- a/public/asset-store/assets-database.json
+++ b/public/asset-store/assets-database.json
@@ -17,7 +17,7 @@
       "likes": 892,
       "usageCount": 2156,
       "tags": ["text", "rotation", "spin", "classic", "gsap", "animation"],
-      "isFavorite": true,
+      "isFavorite": false,
       "createdAt": "2024-01-15T08:30:00Z",
       "updatedAt": "2024-02-01T14:22:00Z"
     },
@@ -66,7 +66,7 @@
       "likes": 1456,
       "usageCount": 3789,
       "tags": ["text", "bounce", "elastic", "spring", "gsap", "animation"],
-      "isFavorite": true,
+      "isFavorite": false,
       "createdAt": "2024-01-25T16:20:00Z",
       "updatedAt": "2024-02-10T11:30:00Z"
     },
@@ -108,7 +108,7 @@
       "likes": 1123,
       "usageCount": 2456,
       "tags": ["text", "magnetic", "pull", "scatter", "gsap", "animation"],
-      "isFavorite": true,
+      "isFavorite": false,
       "createdAt": "2024-02-05T12:00:00Z",
       "updatedAt": "2024-02-20T15:30:00Z"
     },
@@ -171,7 +171,7 @@
       "likes": 1789,
       "usageCount": 3567,
       "tags": ["text", "slide", "up", "modern", "gsap", "animation"],
-      "isFavorite": true,
+      "isFavorite": false,
       "createdAt": "2024-02-15T14:30:00Z",
       "updatedAt": "2024-02-28T16:40:00Z"
     },
@@ -192,7 +192,7 @@
       "likes": 189,
       "usageCount": 567,
       "tags": ["text", "bounce", "speaker", "color", "cwi"],
-      "isFavorite": false,
+      "isFavorite": true,
       "createdAt": "2024-09-10T12:00:00Z",
       "updatedAt": "2024-09-10T12:00:00Z"
     },
@@ -213,7 +213,7 @@
       "likes": 156,
       "usageCount": 423,
       "tags": ["text", "color", "speaker", "palette", "cwi"],
-      "isFavorite": false,
+      "isFavorite": true,
       "createdAt": "2024-09-10T12:00:00Z",
       "updatedAt": "2024-09-10T12:00:00Z"
     },
@@ -255,7 +255,7 @@
       "likes": 89,
       "usageCount": 234,
       "tags": ["text", "whisper", "soft", "fade", "cwi"],
-      "isFavorite": false,
+      "isFavorite": true,
       "createdAt": "2024-09-10T12:00:00Z",
       "updatedAt": "2024-09-10T12:00:00Z"
     },
@@ -339,7 +339,7 @@
       "likes": 823,
       "usageCount": 1567,
       "tags": ["text", "glow", "neon", "light", "smooth", "gsap"],
-      "isFavorite": true,
+      "isFavorite": false,
       "createdAt": "2024-03-12T15:40:00Z",
       "updatedAt": "2024-03-25T12:10:00Z"
     },


### PR DESCRIPTION
개요

  - 애셋 스토어의 즐겨찾기 상태를 업데이트하고 단어 클릭 시 비디오 탐색 정확도를 향상
  - 기존 GSAP 기반 애니메이션의 즐겨찾기를 해제하고 CWI 플러그인을 즐겨찾기로 설정
  - 시나리오 기반 baseTime을 활용한 정확한 비디오 시간 탐색 로직 구현

  설명

  What (무엇을 수정했나요?)

  1. 애셋 데이터베이스 즐겨찾기 상태 변경
    - 기존 GSAP 기반 애니메이션 5개 (rotation, elastic, magnetic, slideUp, glow)의 isFavorite를
  false로 변경
    - CWI 플러그인 3개 (speakerBounce, speakerColorPalette, whisper)의 isFavorite를 true로 변경
  2. ClipWords 컴포넌트의 단어 클릭 탐색 로직 개선
    - currentScenario와 nodeIndex 상태를 추가로 활용
    - 단어 클릭 시 시나리오의 textNode baseTime을 우선적으로 사용하는 로직 구현
    - 기존 word.start 값을 fallback으로 유지

  Why (왜 수정했나요?)

  1. 즐겨찾기 우선순위 조정: CWI에서 개발한 최신 플러그인들을 사용자가 쉽게 찾을 수 있도록 즐겨찾기로
  설정하고, 기존 레거시 GSAP 플러그인들의 우선순위를 낮춤
  2. 정확한 시간 탐색: 기존 word.start 값보다 시나리오 기반 baseTime[0]이 더 정확한 재생 시점을
  제공하여 사용자 경험 향상

  How (어떻게 수정했나요?)

  1. 데이터베이스 업데이트: assets-database.json에서 각 애셋의 isFavorite 플래그를 수동으로 조정
  2. 시나리오 기반 탐색 로직:
    - useEditorStore에서 currentScenario, nodeIndex 추가 추출
    - 단어 ID 매칭 시 word- 접두사 포함/미포함 케이스 모두 처리
    - 시나리오 cue → textNode → baseTime 경로로 정확한 시간 값 추출
    - 탐색 실패 시 기존 word.start 값으로 안전하게 fallback

  📋 체크리스트

  - 기능 테스트 완료 (단어 클릭 시 정확한 시간 탐색 확인)
  - 코드 리뷰 준비 완료
  - 문서 업데이트 (필요시)

  🔍 리뷰 포인트

  - 시나리오 기반 시간 탐색 로직의 안정성 및 fallback 처리 검토
  - nodeIndex 매칭 로직에서 접두사 처리가 올바른지 확인